### PR TITLE
Add Travis CI config file

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,29 @@
+dist: trusty
+sudo: required
+services:
+  - docker
+language: go
+go:
+- 1.9.1
+
+install:
+# This script is used by the Travis build to install a cookie for
+# go.googlesource.com so rate limits are higher when using `go get` to fetch
+# packages that live there.
+# See: https://github.com/golang/go/issues/12933
+- bash scripts/gogetcookie.sh
+- go get github.com/kardianos/govendor
+
+script:
+- make test
+- make vendor-status
+- make vet
+- make website-test
+
+branches:
+  only:
+  - master
+matrix:
+  fast_finish: true
+  allow_failures:
+  - go: tip

--- a/main.go
+++ b/main.go
@@ -2,5 +2,5 @@ package main
 
 func main() {
 	/*plugin.Serve(&plugin.ServeOpts{
-		ProviderFunc: opc.Provider})*/
+	ProviderFunc: opc.Provider})*/
 }


### PR DESCRIPTION
The failure is more-or-less intended. The scaffolding project is not supposed to be as functional as a real provider and the red cross should remind maintainers to fix the failures once a new provider codebase spins off the codebase.

We still can't automate enabling Travis (i.e. set up the Github/Travis API keys), but at least we won't forget to add the `.travis.yml` file and there'll be just one last manual step involving 1 click in the Travis UI.