### PR TITLE
Rename Go package/module path

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,17 +22,17 @@ Requirements
 Building The Provider
 ---------------------
 
-Clone repository to: `$GOPATH/src/github.com/terraform-providers/terraform-provider-scaffolding`
+Clone repository to: `$GOPATH/src/github.com/hashicorp/terraform-provider-scaffolding`
 
 ```sh
-$ mkdir -p $GOPATH/src/github.com/terraform-providers; cd $GOPATH/src/github.com/terraform-providers
-$ git clone git@github.com:terraform-providers/terraform-provider-scaffolding
+$ mkdir -p $GOPATH/src/github.com/hashicorp; cd $GOPATH/src/github.com/hashicorp
+$ git clone git@github.com:hashicorp/terraform-provider-scaffolding
 ```
 
 Enter the provider directory and build the provider
 
 ```sh
-$ cd $GOPATH/src/github.com/terraform-providers/terraform-provider-scaffolding
+$ cd $GOPATH/src/github.com/hashicorp/terraform-provider-scaffolding
 $ make build
 ```
 

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/terraform-providers/terraform-provider-scaffolding
+module github.com/hashicorp/terraform-provider-scaffolding
 
 go 1.12
 

--- a/main.go
+++ b/main.go
@@ -2,7 +2,7 @@ package main
 
 import (
 	"github.com/hashicorp/terraform-plugin-sdk/plugin"
-	"github.com/terraform-providers/terraform-provider-scaffolding/scaffolding" // change this to the import path of your provider
+	"github.com/hashicorp/terraform-provider-scaffolding/scaffolding" // change this to the import path of your provider
 )
 
 func main() {

--- a/scripts/changelog-links.sh
+++ b/scripts/changelog-links.sh
@@ -24,7 +24,7 @@ else
   SED="sed -i.bak -r -e"
 fi
 
-PROVIDER_URL="https:\/\/github.com\/terraform-providers\/terraform-provider-scaffolding\/issues"
+PROVIDER_URL="https:\/\/github.com\/hashicorp\/terraform-provider-scaffolding\/issues"
 
 $SED "s/GH-([0-9]+)/\[#\1\]\($PROVIDER_URL\/\1\)/g" -e 's/\[\[#(.+)([0-9])\)]$/(\[#\1\2))/g' CHANGELOG.md
 


### PR DESCRIPTION
The repo was moved from github.com/terraform-providers/terraform-provider-scaffolding to github.com/hashicorp/terraform-provider-scaffolding