### PR TITLE
Add goreleaser config

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@ example.tf
 terraform.tfplan
 terraform.tfstate
 bin/
+dist/
 modules-dev/
 /pkg/
 website/.vagrant

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -36,10 +36,6 @@ builds:
       goarch: arm64
     - goos: solaris
       goarch: '386'
-    - goos: windows
-      goarch: arm
-    - goos: windows
-      goarch: arm64
   binary: '{{ .ProjectName }}_v{{ .Version }}'
 archives:
 - format: zip

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,0 +1,63 @@
+# Visit https://goreleaser.com for documentation on how to customize this
+# behavior.
+
+before:
+  hooks:
+    - go mod tidy
+builds:
+- env:
+  - CGO_ENABLED=0
+  goos:
+    - freebsd
+    - openbsd
+    - solaris
+    - windows
+    - linux
+    - darwin
+  goarch:
+    - amd64
+    - '386'
+    - arm
+    - arm64
+  ignore:
+    - goos: darwin
+      goarch: '386'
+    - goos: darwin
+      goarch: arm
+    - goos: darwin
+      goarch: arm64
+    - goos: openbsd
+      goarch: arm
+    - goos: openbsd
+      goarch: arm64
+    - goos: solaris
+      goarch: arm
+    - goos: solaris
+      goarch: arm64
+    - goos: solaris
+      goarch: '386'
+    - goos: windows
+      goarch: arm
+    - goos: windows
+      goarch: arm64
+  binary: '{{ .ProjectName }}_v{{ .Version }}'
+archives:
+- format: zip
+  name_template: '{{ .ProjectName }}_{{ .Version }}_{{ .Os }}_{{ .Arch }}'
+checksum:
+  name_template: '{{ .ProjectName }}_{{ .Version }}_SHA256SUMS'
+  algorithm: sha256
+signs:
+  - artifacts: checksum
+    args:
+      - "--local-user"
+      - "51852D87348FFC4C" # Replace this with your GPG signing key ID
+      - "--output"
+      - "${signature}"
+      - "--detach-sign"
+      - "${artifact}"
+release:
+  # Visit your project's GitHub Releases page to publish this release.
+  draft: true
+changelog:
+  skip: true


### PR DESCRIPTION
Adds a [goreleaser](goreleaser.com) config, which we're currently using for publishing providers to the Terraform Registry during the private beta period. This will act as a reference for provider authors to build, sign, and release their providers to GitHub Releases for eventually publishing providers to the Registry.