### PR TITLE
Context aware scaffolding

### DIFF
--- a/internal/provider/data_source_scaffolding.go
+++ b/internal/provider/data_source_scaffolding.go
@@ -1,14 +1,15 @@
 package provider
 
 import (
-	"errors"
+	"context"
 
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
 
 func dataSourceScaffolding() *schema.Resource {
 	return &schema.Resource{
-		Read: dataSourceScaffoldingRead,
+		ReadContext: dataSourceScaffoldingRead,
 
 		Schema: map[string]*schema.Schema{
 			"sample_attribute": {
@@ -19,9 +20,12 @@ func dataSourceScaffolding() *schema.Resource {
 	}
 }
 
-func dataSourceScaffoldingRead(d *schema.ResourceData, meta interface{}) error {
+func dataSourceScaffoldingRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	// use the meta value to retrieve your client from the provider configure method
 	// client := meta.(*apiClient)
 
-	return errors.New("Not implemented")
+	idFromAPI := "my-id"
+	d.SetId(idFromAPI)
+
+	return diag.Errorf("not implemented")
 }

--- a/internal/provider/data_source_scaffolding_test.go
+++ b/internal/provider/data_source_scaffolding_test.go
@@ -16,7 +16,7 @@ func TestAccDataSourceScaffolding(t *testing.T) {
 				Config: testAccDataSourceScaffolding,
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestMatchResourceAttr(
-						"scaffolding_data_source.foo", "sample_attribute", regexp.MustCompile("^ba")),
+						"data.scaffolding_data_source.foo", "sample_attribute", regexp.MustCompile("^ba")),
 				),
 			},
 		},

--- a/internal/provider/resource_scaffolding.go
+++ b/internal/provider/resource_scaffolding.go
@@ -1,17 +1,18 @@
 package provider
 
 import (
-	"errors"
+	"context"
 
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
 
 func resourceScaffolding() *schema.Resource {
 	return &schema.Resource{
-		Create: resourceScaffoldingCreate,
-		Read:   resourceScaffoldingRead,
-		Update: resourceScaffoldingUpdate,
-		Delete: resourceScaffoldingDelete,
+		CreateContext: resourceScaffoldingCreate,
+		ReadContext:   resourceScaffoldingRead,
+		UpdateContext: resourceScaffoldingUpdate,
+		DeleteContext: resourceScaffoldingDelete,
 
 		Schema: map[string]*schema.Schema{
 			"sample_attribute": {
@@ -22,30 +23,33 @@ func resourceScaffolding() *schema.Resource {
 	}
 }
 
-func resourceScaffoldingCreate(d *schema.ResourceData, meta interface{}) error {
+func resourceScaffoldingCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	// use the meta value to retrieve your client from the provider configure method
 	// client := meta.(*apiClient)
 
-	return errors.New("Not implemented")
+	idFromAPI := "my-id"
+	d.SetId(idFromAPI)
+
+	return diag.Errorf("not implemented")
 }
 
-func resourceScaffoldingRead(d *schema.ResourceData, meta interface{}) error {
+func resourceScaffoldingRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	// use the meta value to retrieve your client from the provider configure method
 	// client := meta.(*apiClient)
 
-	return errors.New("Not implemented")
+	return diag.Errorf("not implemented")
 }
 
-func resourceScaffoldingUpdate(d *schema.ResourceData, meta interface{}) error {
+func resourceScaffoldingUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	// use the meta value to retrieve your client from the provider configure method
 	// client := meta.(*apiClient)
 
-	return errors.New("Not implemented")
+	return diag.Errorf("not implemented")
 }
 
-func resourceScaffoldingDelete(d *schema.ResourceData, meta interface{}) error {
+func resourceScaffoldingDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	// use the meta value to retrieve your client from the provider configure method
 	// client := meta.(*apiClient)
 
-	return errors.New("Not implemented")
+	return diag.Errorf("not implemented")
 }


### PR DESCRIPTION
This PR focuses on issue #28 that requests updates to the scaffolding resources and datasources to use the context aware variants of the CRUD functions.  The HashiCorp guide [Writing Custom Providers](https://www.terraform.io/docs/extend/writing-custom-providers.html) has already been updated to use the newer functions and this will align the repo with the docs.

While exploring the repo and using it as a template, I noticed that the acceptance tests did not work and the second part is to allow a new generated provider from the template to test successfully through `make testacc`.  The repo can be checked out or a new repo can be seeded and the acceptance tests will execute with a pass against resource and datasource.

NOTE:
- The tests did need to be expanded, but I used the guide previously mentioned to try and keep them consistent.
- The tests should still remain in the spirit with the originals and just provide confidence that a new provider is ready to be developed.