### PR TITLE
Fix base implementation to compile and return understandable error during acceptance tests

### DIFF
--- a/internal/provider/data_source_scaffolding.go
+++ b/internal/provider/data_source_scaffolding.go
@@ -1,6 +1,8 @@
 package provider
 
 import (
+	"errors"
+
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
 
@@ -21,5 +23,5 @@ func dataSourceScaffoldingRead(d *schema.ResourceData, meta interface{}) error {
 	// use the meta value to retrieve your client from the provider configure method
 	// client := meta.(*apiClient)
 
-	return nil
+	return errors.New("Not implemented")
 }

--- a/internal/provider/data_source_scaffolding_test.go
+++ b/internal/provider/data_source_scaffolding_test.go
@@ -24,7 +24,7 @@ func TestAccDataSourceScaffolding(t *testing.T) {
 }
 
 const testAccDataSourceScaffolding = `
-resource "scaffolding_data_source" "foo" {
+data "scaffolding_data_source" "foo" {
   sample_attribute = "bar"
 }
 `

--- a/internal/provider/provider_test.go
+++ b/internal/provider/provider_test.go
@@ -11,12 +11,12 @@ import (
 // to create a provider server to which the CLI can reattach.
 var providerFactories = map[string]func() (*schema.Provider, error){
 	"scaffolding": func() (*schema.Provider, error) {
-		return New(), nil
+		return New("dev")(), nil
 	},
 }
 
 func TestProvider(t *testing.T) {
-	if err := New().InternalValidate(); err != nil {
+	if err := New("dev")().InternalValidate(); err != nil {
 		t.Fatalf("err: %s", err)
 	}
 }

--- a/internal/provider/resource_scaffolding.go
+++ b/internal/provider/resource_scaffolding.go
@@ -26,7 +26,7 @@ func resourceScaffoldingCreate(d *schema.ResourceData, meta interface{}) error {
 	// use the meta value to retrieve your client from the provider configure method
 	// client := meta.(*apiClient)
 
-	return resourceScaffoldingRead(d, meta)
+	return errors.New("Not implemented")
 }
 
 func resourceScaffoldingRead(d *schema.ResourceData, meta interface{}) error {
@@ -40,7 +40,7 @@ func resourceScaffoldingUpdate(d *schema.ResourceData, meta interface{}) error {
 	// use the meta value to retrieve your client from the provider configure method
 	// client := meta.(*apiClient)
 
-	return resourceScaffoldingRead(d, meta)
+	return errors.New("Not implemented")
 }
 
 func resourceScaffoldingDelete(d *schema.ResourceData, meta interface{}) error {

--- a/internal/provider/resource_scaffolding.go
+++ b/internal/provider/resource_scaffolding.go
@@ -1,6 +1,8 @@
 package provider
 
 import (
+	"errors"
+
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
 
@@ -24,26 +26,26 @@ func resourceScaffoldingCreate(d *schema.ResourceData, meta interface{}) error {
 	// use the meta value to retrieve your client from the provider configure method
 	// client := meta.(*apiClient)
 
-	return nil
+	return resourceScaffoldingRead(d, meta)
 }
 
 func resourceScaffoldingRead(d *schema.ResourceData, meta interface{}) error {
 	// use the meta value to retrieve your client from the provider configure method
 	// client := meta.(*apiClient)
 
-	return nil
+	return errors.New("Not implemented")
 }
 
 func resourceScaffoldingUpdate(d *schema.ResourceData, meta interface{}) error {
 	// use the meta value to retrieve your client from the provider configure method
 	// client := meta.(*apiClient)
 
-	return nil
+	return resourceScaffoldingRead(d, meta)
 }
 
 func resourceScaffoldingDelete(d *schema.ResourceData, meta interface{}) error {
 	// use the meta value to retrieve your client from the provider configure method
 	// client := meta.(*apiClient)
 
-	return nil
+	return errors.New("Not implemented")
 }


### PR DESCRIPTION
This PR intends to improve the experience when copying this template repository and running acceptance tests for the first time.

Without the changes:

```
make testacc
TF_ACC=1 go test ./... -v  -timeout 120m
?       github.com/hashicorp/terraform-provider-scaffolding     [no test files]
# github.com/hashicorp/terraform-provider-scaffolding/internal/provider [github.com/hashicorp/terraform-provider-scaffolding/internal/provider.test]
internal/provider/provider_test.go:14:13: not enough arguments in call to New
        have ()
        want (string)
internal/provider/provider_test.go:14:13: cannot use New() (type func() *schema.Provider) as type *schema.Provider in return argument
internal/provider/provider_test.go:19:15: not enough arguments in call to New
        have ()
        want (string)
internal/provider/provider_test.go:19:17: New().InternalValidate undefined (type func() *schema.Provider has no field or method InternalValidate)
FAIL    github.com/hashicorp/terraform-provider-scaffolding/internal/provider [build failed]
FAIL
make: *** [GNUmakefile:6: testacc] Error 2
```
﻿
With this PR:

```
make testacc
TF_ACC=1 go test ./... -v  -timeout 120m
?       github.com/hashicorp/terraform-provider-scaffolding     [no test files]
=== RUN   TestAccDataSourceScaffolding
    data_source_scaffolding_test.go:11: Step 1/1 error: Error running pre-apply refresh:
        Error: Not implemented


--- FAIL: TestAccDataSourceScaffolding (0.33s)
=== RUN   TestProvider
--- PASS: TestProvider (0.00s)
=== RUN   TestAccResourceScaffolding
    resource_scaffolding_test.go:11: Step 1/1 error: Error running apply:
        Error: Not implemented


--- FAIL: TestAccResourceScaffolding (0.51s)
FAIL
FAIL    github.com/hashicorp/terraform-provider-scaffolding/internal/provider   0.865s
FAIL
make: *** [GNUmakefile:6: testacc] Error 1
```
