### PR TITLE
goreleaser: Build OpenBSD binaries.

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -20,6 +20,7 @@ builds:
     - windows
     - linux
     - darwin
+    - openbsd
   goarch:
     - amd64
     - '386'
@@ -28,6 +29,10 @@ builds:
   ignore:
     - goos: darwin
       goarch: '386'
+    - goos: openbsd
+      goarch: arm
+    - goos: openbsd
+      goarch: arm64
   binary: '{{ .ProjectName }}_v{{ .Version }}'
 archives:
 - format: zip
@@ -38,7 +43,7 @@ checksum:
 signs:
   - artifacts: checksum
     args:
-      # if you are using this is a GitHub action or some other automated pipeline, you 
+      # if you are using this is a GitHub action or some other automated pipeline, you
       # need to pass the batch flag to indicate its not interactive.
       - "--batch"
       - "--local-user"


### PR DESCRIPTION
When HashiCorp built and released providers, OpenBSD binaries were included. In the DigitalOcean provider, we received a report from a user who had recently upgraded and found OpenBSD support to be missing (https://github.com/digitalocean/terraform-provider-digitalocean/issues/533).

Feel free to close if this isn't judged to not be needed, but existing providers might want parity with what they had previously offered.

Looking back at the last release before the transition to the registry distribution model, OpenBSD binaries were provided for i386 and amd64. So I've skipped the ARM builds. This also matches with the OpenBSD support for Terraform binaries provided by HashiCorp: https://www.terraform.io/downloads.html