### PR TITLE
.github/workflows: Update goreleaser to use parallelism 2 to match GitHub Actions hosted runners

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -41,7 +41,7 @@ jobs:
         uses: goreleaser/goreleaser-action@v2
         with:
           version: latest
-          args: release --rm-dist
+          args: release --parallelism 2 --rm-dist
         env:
           GPG_FINGERPRINT: ${{ steps.import_gpg.outputs.fingerprint }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
The parallelism flag defaults to `4`, which on larger providers can trigger unexpectedly long run times and potentially the `oom-killer`.