### PR TITLE
.github/workflows: Remove goreleaser parallelism

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -41,7 +41,7 @@ jobs:
         uses: goreleaser/goreleaser-action@v2
         with:
           version: latest
-          args: release --parallelism 2 --rm-dist
+          args: release --rm-dist
         env:
           GPG_FINGERPRINT: ${{ steps.import_gpg.outputs.fingerprint }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Reference: https://github.com/goreleaser/goreleaser/issues/2013
Reference: https://github.com/hashicorp/terraform-provider-scaffolding/pull/48

Upstream `goreleaser` now includes parallelism that defaults to the number of CPUs. The `goreleaser/goreleaser-action` GitHub Action defaults to using the latest available version (which is also hardcoded in the configuration).

```console
$ system_profiler -detailLevel mini SPHardwareDataType
Hardware:

    Hardware Overview:

      Model Name: MacBook Pro
      Model Identifier: MacBookPro15,1
      Processor Name: 8-Core Intel Core i9
      Processor Speed: 2.4 GHz
      Number of Processors: 1
      Total Number of Cores: 8
      L2 Cache (per Core): 256 KB
      L3 Cache: 16 MB
      Hyper-Threading Technology: Enabled
      Memory: 32 GB
      Boot ROM Version: 1037.147.4.0.0 (iBridge: 17.16.16610.0.0,0)
$ goreleaser --version
goreleaser version 0.155.0
commit: ba82f43c5f2eefcc82d8d14634fe21b37ffc1799
built by: homebrew
$ goreleaser build --help
Builds the current project
...
  -p, --parallelism int    Amount tasks to run concurrently (default 16)
```