### PR TITLE
goreleaser darwin build

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,6 +15,38 @@ on:
     tags:
       - 'v*'
 jobs:
+  goreleaser-darwin:
+    runs-on: macos-latest
+    steps:
+      -
+        name: Checkout
+        uses: actions/checkout@v2.3.4
+      -
+        name: Unshallow
+        run: git fetch --prune --unshallow
+      -
+        name: Set up Go
+        uses: actions/setup-go@v2
+        with:
+          go-version: 1.14
+      -
+        name: Import GPG key
+        id: import_gpg
+        uses: hashicorp/ghaction-import-gpg@v2.1.0
+        env:
+          # These secrets will need to be configured for the repository:
+          GPG_PRIVATE_KEY: ${{ secrets.GPG_PRIVATE_KEY }}
+          PASSPHRASE: ${{ secrets.PASSPHRASE }}
+      -
+        name: Run GoReleaser
+        uses: goreleaser/goreleaser-action@v2.5.0
+        with:
+          version: latest
+          args: release --rm-dist --id=darwin
+        env:
+          GPG_FINGERPRINT: ${{ steps.import_gpg.outputs.fingerprint }}
+          # GitHub sets this automatically
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   goreleaser:
     runs-on: ubuntu-latest
     steps:
@@ -42,7 +74,7 @@ jobs:
         uses: goreleaser/goreleaser-action@v2.5.0
         with:
           version: latest
-          args: release --rm-dist
+          args: release --rm-dist --id=default
         env:
           GPG_FINGERPRINT: ${{ steps.import_gpg.outputs.fingerprint }}
           # GitHub sets this automatically

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -5,7 +5,28 @@ before:
     # this is just an example and not a requirement for provider building/publishing
     - go mod tidy
 builds:
-- env:
+# In cases when behind a VPN, plugins that make DNS queries need to use 
+# the system DNS resolver in order to function. This requires the netcgo 
+# tag be enabled,CGO not explicitly disabled, and the builds to happen on
+# a darwin host. Separate the darwin builds out so tha we are able to 
+# handle the different requirements in CI.
+- id: darwin
+  env:
+  mod_timestamp: '{{ .CommitTimestamp }}'
+  flags:
+    - -trimpath
+    - -tags=netcgo
+  ldflags:
+    - '-s -w -X main.version={{.Version}} -X main.commit={{.Commit}}'
+  goos:
+    - darwin
+  goarch:
+    - amd64
+    - arm
+    - arm64
+  binary: '{{ .ProjectName }}_v{{ .Version }}'
+- id: default
+  env:
     # goreleaser does not work with CGO, it could also complicate
     # usage by users in CI/CD systems like Terraform Cloud where
     # they are unable to install libraries.
@@ -19,15 +40,11 @@ builds:
     - freebsd
     - windows
     - linux
-    - darwin
   goarch:
     - amd64
     - '386'
     - arm
     - arm64
-  ignore:
-    - goos: darwin
-      goarch: '386'
   binary: '{{ .ProjectName }}_v{{ .Version }}'
 archives:
 - format: zip

--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@ This repository is a *template* for a [Terraform](https://www.terraform.io) prov
 
  - A resource, and a data source (`internal/provider/`),
  - Examples (`examples/`) and generated documentation (`docs/`),
+ - GitHub Actions workflows for `test` and `release`.
  - Miscellaneous meta files.
  
 These files contain boilerplate code that you will need to edit to create your own Terraform provider. A full guide to creating Terraform providers can be found at [Writing Custom Providers](https://www.terraform.io/docs/extend/writing-custom-providers.html).
@@ -60,3 +61,17 @@ In order to run the full suite of Acceptance tests, run `make testacc`.
 ```sh
 $ make testacc
 ```
+
+## Releasing the Provider
+
+To release a new version of a provider, add a tag to the commit you want to release in the format `vX.Y.Z` and push it.
+GitHub Actions is configured to treat these tags as releases. E.g.:
+
+```
+git tag -am "Release v0.1.2" v0.1.2
+git push origin v0.1.2
+```
+
+Note that the macOS (darwin) build must be run on a macOS host in order to have correct DNS lookup behavior.
+The included GitHub Actions config in `.github/workflows/release.yml` is configured
+to trigger the darwin build defined in `.goreleaser.yml` separately on a mac executor for this reason.


### PR DESCRIPTION
- Adds a separate goreleaser build for darwin binaries that includes the `netcgo` build tag.
- Modifies GH Actions config to invoke this build separately on a macOS executor.
- Darwin binaries thus built should have correct DNS lookup behaviour even when on VPN as they bind to the mac SDK implementation rather than using the go stdlib implementation.