### PR TITLE
Update go version to 1.16

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,7 +28,7 @@ jobs:
         name: Set up Go
         uses: actions/setup-go@v2
         with:
-          go-version: 1.14
+          go-version: 1.16
       -
         name: Import GPG key
         id: import_gpg


### PR DESCRIPTION
This resolves the following warning when using the `release` action:

>         • DEPRECATED: skipped darwin/arm64 build on Go < 1.16 for compatibility, check https://goreleaser.com/deprecations/#builds-for-darwinarm64 for more info.

And the following error:

>    ⨯ release failed after 1503.99s error=failed to build for windows_arm_6: # github.com/terraform-providers/terraform-provider-aws/aws/internal/service/eks/token
aws/internal/service/eks/token/token.go:320:23: undefined: io.ReadAll
note: module requires Go 1.16

As seen in [this run](https://github.com/jfirebaugh/terraform-provider-aws/runs/3109246876).