### PR TITLE
Update test workflow for latest Terraform CLI minor releases

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -51,9 +51,11 @@ jobs:
       matrix:
         # list whatever Terraform versions here you would like to support
         terraform:
-          - '0.12.29'
-          - '0.13.4'
-          - '0.14.0-beta2'
+          - '0.12.31'
+          - '0.13.7'
+          - '0.14.11'
+          - '0.15.5'
+          - '1.0.11'
     steps:
 
     - name: Set up Go


### PR DESCRIPTION
In the future, the Terraform Plugin SDK may be able to support minor version constraints in the testing framework Terraform CLI installation process. Otherwise this workflow can be updated to use the hashicorp/setup-terraform GitHub Action instead of the `TF_ACC_TERRAFORM_VERSION` environment variable for the testing framework.

Reference: https://github.com/hashicorp/setup-terraform#inputs