### PR TITLE
docs: Update README link to Learn platform content

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ This repository is a *template* for a [Terraform](https://www.terraform.io) prov
  - Examples (`examples/`) and generated documentation (`docs/`),
  - Miscellaneous meta files.
  
-These files contain boilerplate code that you will need to edit to create your own Terraform provider. A full guide to creating Terraform providers can be found at [Writing Custom Providers](https://www.terraform.io/docs/extend/writing-custom-providers.html).
+These files contain boilerplate code that you will need to edit to create your own Terraform provider. Tutorials for creating Terraform providers can be found on the [HashiCorp Learn](https://learn.hashicorp.com/collections/terraform/providers) platform.
 
 Please see the [GitHub template repository documentation](https://help.github.com/en/github/creating-cloning-and-archiving-repositories/creating-a-repository-from-a-template) for how to create a new repository from this template on GitHub.
 


### PR DESCRIPTION
Closes #88
Reference: https://github.com/hashicorp/terraform-website/pull/2057

Matching the sentence and updated URL from https://github.com/hashicorp/terraform-provider-scaffolding-framework.