### PR TITLE
Add a release helper script

### DIFF
--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -1,0 +1,130 @@
+#!/bin/bash
+
+REPO_DIR="$(cd "$(dirname "$0")"/.. && pwd)"
+cd "${REPO_DIR}"
+
+# Uncomment the following line and specify the GitHub repository for this provider
+#PROVIDER_REPO="hashicorp/terraform-provider-scaffolding"
+TRUNK="main"
+
+usage() {
+  echo "Usage: $0 -y [-C] [-T] [-f]" >&2
+  echo >&2
+  echo " -y  Proceed with release. Must be specified." >&2
+  echo " -C  Only prepare the changelog; do not commit, tag or push" >&2
+  echo " -T  Skip tests before preparing release" >&2
+  echo " -f  Force release prep when \`${TRUNK}\` branch is not checked out" >&2
+  echo >&2
+}
+
+while getopts ':yCTfh' opt; do
+  case "$opt" in
+    y)
+      GOTIME=1
+      ;;
+    C)
+      NOTAG=1
+      ;;
+    T)
+      NOTEST=1
+      ;;
+    f)
+      FORCE=1
+      ;;
+    *)
+      usage
+      exit 1
+      ;;
+  esac
+done
+
+if [[ "${GOTIME}" != "1" ]]; then
+  echo "Specify \`-y\` to initiate release!" >&2
+  usage
+  exit 1
+fi
+
+if [[ ! "${PROVIDER_REPO}" =~ ^[^/]+/[^/]+$ ]]; then
+  echo "Please set the PROVIDER_REPO variable in the release script" >&2
+  exit 9
+fi
+
+if [[ "$(uname)" == "Darwin" ]]; then
+  echo "(Using BSD sed)"
+  SED="sed -E"
+else
+  echo "(Using GNU sed)"
+  SED="sed -r"
+fi
+
+DATE="$(date '+%B %d, %Y')"
+PROVIDER_URL="https:\/\/github.com\/${PROVIDER_REPO}\/issues"
+
+BRANCH="$(git rev-parse --abbrev-ref HEAD)"
+if [[ "${BRANCH}" != "${TRUNK}" ]]; then
+  if [[ "${FORCE}" == "1" ]]; then
+    echo "Caution: Proceeding with release prep on branch: ${BRANCH}"
+  else
+    echo "Release must be prepped on \`${TRUNK}\` branch. Specify \`-f\` to override." >&2
+    exit 1
+  fi
+fi
+
+if [[ "$(git status --short)" != "" ]]; then
+  echo "Error: working tree is dirty" >&2
+  exit 4
+fi
+
+set -e
+
+if [[ "${NOTEST}" == "1" ]]; then
+  echo "Warning: Skipping tests"
+else
+  echo "Running tests..."
+  ( set -x; TF_ACC= scripts/run-test.sh )
+fi
+
+echo "Preparing changelog for release..."
+
+if [[ ! -f CHANGELOG.md ]]; then
+  echo "Error: CHANGELOG.md not found."
+  exit 2
+fi
+
+# Get the next release
+RELEASE="$($SED -n 's/^## v?([0-9.]+) \(Unreleased\)/\1/p' CHANGELOG.md)"
+if [[ "${RELEASE}" == "" ]]; then
+  echo "Error: could not determine next release in CHANGELOG.md" >&2
+  exit 3
+fi
+
+# Ensure latest changes are checked out
+( set -x; git pull --rebase origin "${TRUNK}" )
+
+# Replace [GH-nnnn] references with issue links
+( set -x; $SED -i.bak "s/\[GH-([0-9]+)\]/\(\[#\1\]\(${PROVIDER_URL}\/\1\)\)/g" CHANGELOG.md )
+
+# Set the date for the latest release
+( set -x; $SED -i.bak "s/^(## v?[0-9.]+) \(Unreleased\)/\1 (${DATE})/i" CHANGELOG.md )
+
+rm CHANGELOG.md.bak
+
+if [[ "${NOTAG}" == "1" ]]; then
+  echo "Warning: Skipping commit, tag and push."
+  exit 0
+fi
+
+echo "Committing changelog..."
+(
+  set -x
+  git commit CHANGELOG.md -m v"${RELEASE}"
+  git push origin "${BRANCH}"
+)
+
+echo "Releasing v${RELEASE}..."
+
+(
+  set -x
+  git tag v"${RELEASE}"
+  git push origin v"${RELEASE}"
+)


### PR DESCRIPTION
The proposed script is being used mostly verbatim in the hashicorp/azurerm and hashicorp/azuread providers; it's a minimalist but extensible approach to processing a conventional changelog, performing general safety checks and wrapping up the version tagging in advance of the `release` workflow being invoked by GitHub Actions.

Before use, the maintainer must set the repository path in the script.
This is checked in the script before proceeding with any further steps.

With no options disabled, running `scripts/release.sh -y` will:
- Check a few things like having a clean working tree and checked out main branch, then run unit tests
- Look for an (Unreleased) version in the changelog and set the current date for it
- Replace [GH-123] style link refs in the changelog
- Commit and push the changelog
- Mint a new tag and push it

Closing any potential milestones on GitHub is left as an exercise for the maintainer.