### PR TITLE
Cache Go dependencies and detect Go version in GitHub Action workflows

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,7 +28,7 @@ jobs:
         name: Set up Go
         uses: actions/setup-go@v3
         with:
-          go-version: 1.17
+          go-version-file: 'go.mod'
       -
         name: Import GPG key
         id: import_gpg

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,6 +29,7 @@ jobs:
         uses: actions/setup-go@v3
         with:
           go-version-file: 'go.mod'
+          cache: true
       -
         name: Import GPG key
         id: import_gpg

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -23,14 +23,15 @@ jobs:
     timeout-minutes: 5
     steps:
 
+    - name: Check out code into the Go module directory
+      uses: actions/checkout@v3
+
     - name: Set up Go
       uses: actions/setup-go@v3
       with:
         go-version-file: 'go.mod'
+        cache: true
       id: go
-
-    - name: Check out code into the Go module directory
-      uses: actions/checkout@v3
 
     - name: Get dependencies
       run: |
@@ -43,10 +44,11 @@ jobs:
   generate:
     runs-on: ubuntu-latest
     steps:
+      - uses: actions/checkout@v3
       - uses: actions/setup-go@v3
         with:
           go-version-file: 'go.mod'
-      - uses: actions/checkout@v3
+          cache: true
       - run: go generate ./...
       - name: git diff
         run: |
@@ -72,19 +74,20 @@ jobs:
           - '1.1.*'
     steps:
 
+    - name: Check out code into the Go module directory
+      uses: actions/checkout@v3
+
     - name: Set up Go
       uses: actions/setup-go@v3
       with:
         go-version-file: 'go.mod'
+        cache: true
       id: go
 
     - uses: hashicorp/setup-terraform@v2
       with:
         terraform_version: ${{ matrix.terraform }}
         terraform_wrapper: false
-
-    - name: Check out code into the Go module directory
-      uses: actions/checkout@v3
 
     - name: Get dependencies
       run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -26,7 +26,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v3
       with:
-        go-version: '1.16'
+        go-version-file: 'go.mod'
       id: go
 
     - name: Check out code into the Go module directory
@@ -45,7 +45,7 @@ jobs:
     steps:
       - uses: actions/setup-go@v3
         with:
-          go-version: '1.16'
+          go-version-file: 'go.mod'
       - uses: actions/checkout@v3
       - run: go generate ./...
       - name: git diff
@@ -75,7 +75,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v3
       with:
-        go-version: '1.17'
+        go-version-file: 'go.mod'
       id: go
 
     - uses: hashicorp/setup-terraform@v2


### PR DESCRIPTION
This PR contains the following:

- Enable caching of Go dependencies by default - see [here][0]
- Detect Go version using `go.mod` – see [here][1]

[0]: https://github.com/actions/setup-go#caching-dependency-files-and-build-outputs
[1]: https://github.com/actions/setup-go#getting-go-version-from-the-gomod-file