### PR TITLE
ci: replace forked GH action with latest upstream

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -32,12 +32,11 @@ jobs:
           cache: true
       -
         name: Import GPG key
+        uses: crazy-max/ghaction-import-gpg@v5
         id: import_gpg
-        uses: hashicorp/ghaction-import-gpg@v2.1.0
-        env:
-          # These secrets will need to be configured for the repository:
-          GPG_PRIVATE_KEY: ${{ secrets.GPG_PRIVATE_KEY }}
-          PASSPHRASE: ${{ secrets.PASSPHRASE }}
+        with:
+          gpg_private_key: ${{ secrets.GPG_PRIVATE_KEY }}
+          passphrase: ${{ secrets.PASSPHRASE }}
       -
         name: Run GoReleaser
         uses: goreleaser/goreleaser-action@v3.0.0


### PR DESCRIPTION
The main blocker and reason for the fork (support of subkeys) seems to be resolved now:
https://github.com/crazy-max/ghaction-import-gpg/issues/58

--- 

Unrelated: I noticed [this action](https://github.com/hashicorp/terraform-provider-scaffolding/blob/main/.github/workflows/add-content-to-project.yml) also, which doesn't seem relevant for this repo - was that perhaps accidentally copied from somewhere else?