### PR TITLE
CI: limit github token permissions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,6 +14,8 @@ on:
   push:
     tags:
       - 'v*'
+permissions:
+  contents: write
 jobs:
   goreleaser:
     runs-on: ubuntu-latest


### PR DESCRIPTION
This makes sure that goreleaser has limited permissions in the GitHub actions run